### PR TITLE
Fix for 5 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "glob": "^3.2.11",
     "handlebars": "^2.0.0-alpha.4",
     "marked": "^0.3.2",
-    "request": "~2.30.0",
+    "request": "~2.74.0",
     "workshopper-jlord": "^0.0.6",
     "cheerio": "~0.17.0"
   }


### PR DESCRIPTION
git-it currently has a 6 vulnerable dependencies, introducing 10 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, introducing [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency, [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency,[Dos(Memory Exhaustion) vulnerability](https://snyk.io/vuln/npm:qs:20140806) and [Dos(Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency,[ReDos vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.

You can see [Snyk test report](https://snyk.io/test/github/jlord/git-it) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade ` prompt`, `  handlebars`, ` ecstatic` and `  glob`  dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)